### PR TITLE
Adjust Media Renderer search criteria, fix metadata bug

### DIFF
--- a/playto-tools.ps1
+++ b/playto-tools.ps1
@@ -238,7 +238,7 @@ function Suspend-CertifiedDeviceChecks
 
 function Get-MediaRenderers()
 {
-    Get-WmiObject Win32_PnPEntity | ? { $_.HardwareID -Like "UMB\*" } | Select Name, HardwareID
+    Get-WmiObject Win32_PnPEntity | ? { $_.CompatibleID -Like "*MediaRenderer*" -or $_.CompatibleID -Like "*\MS_*DMR*"  } | Select Name, HardwareID
 }
 
 function New-DeviceMetadata()

--- a/playto-tools.ps1
+++ b/playto-tools.ps1
@@ -238,7 +238,7 @@ function Suspend-CertifiedDeviceChecks
 
 function Get-MediaRenderers()
 {
-    Get-WmiObject Win32_PnPEntity | ? { $_.HardwareID -Like "*MediaRenderer*" } | Select Name, HardwareID
+    Get-WmiObject Win32_PnPEntity | ? { $_.HardwareID -Like "UMB\*" } | Select Name, HardwareID
 }
 
 function New-DeviceMetadata()
@@ -267,7 +267,7 @@ function New-DeviceMetadata()
     $pkginfo = "$scratch\PackageInfo.xml"
 
     (Get-Content $pkginfo | ForEach {
-        $buffer = $_ -replace "{hwid}", "DOID:$($device.HardwareID[0])"
+        $buffer = $_ -replace "{hwid}", [System.Web.HttpUtility]::HtmlEncode("DOID:$($device.HardwareID[0])")
         $buffer = $buffer -replace "{lastmodified}", ([DateTime]::UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"))
         $buffer -replace "{experienceid}", $scratch }) | Out-File $pkginfo -Encoding utf8
     


### PR DESCRIPTION
Changing Get-MediaRenderers to list all "UMB*" devices which should
contain all available DLNA devices, plus a few extra redundant stuff,
but better more than less right? Users should be able to easily
distinguish their devices from the list.

Adding a missing HtmlEncode to the hardware id for the PackageInfo.xml
file. My AVR had a '&' in it's name which required HtmlEncoding. Worked
like a charm after I added it :)
