### PR TITLE
load System.Web assembly

### DIFF
--- a/playto-tools.ps1
+++ b/playto-tools.ps1
@@ -1,5 +1,7 @@
 #requires -Version 3.0
 
+Add-Type -AssemblyName System.Web
+
 function Suspend-CertifiedDeviceChecks
 {
     $_unwind = New-Object Collections.Stack


### PR DESCRIPTION
Without `System.Web` `[System.Web.HttpUtility]::HtmlEncode` won't work
